### PR TITLE
ENH appveyor is ok list

### DIFF
--- a/appveyor_ok_list.json
+++ b/appveyor_ok_list.json
@@ -1,1 +1,1 @@
-{"ok": ["armadillo", "gdcm", "isl", "libssh2", "simbody", "sdl2_mixer", "czmq", "helics", "gsl-lite"]}
+{"ok": ["gdcm", "isl", "simbody", "sdl2_mixer", "czmq", "helics", "gsl-lite"]}

--- a/appveyor_ok_list.json
+++ b/appveyor_ok_list.json
@@ -1,1 +1,1 @@
-{"ok": ["armadillo", "gdcm", "isl", "libssh2", "simbody", "sdl2_mixer", "sdl2_image", "czmq", "helics", "gsl-lite"]}
+{"ok": ["armadillo", "gdcm", "isl", "libssh2", "simbody", "sdl2_mixer", "czmq", "helics", "gsl-lite"]}

--- a/appveyor_ok_list.json
+++ b/appveyor_ok_list.json
@@ -1,1 +1,1 @@
-{"ok": ["isl", "simbody", "sdl2_mixer", "gsl-lite"]}
+{"ok": ["isl"]}

--- a/appveyor_ok_list.json
+++ b/appveyor_ok_list.json
@@ -1,1 +1,1 @@
-{"ok": ["isl", "simbody", "sdl2_mixer", "czmq", "helics", "gsl-lite"]}
+{"ok": ["isl", "simbody", "sdl2_mixer", "helics", "gsl-lite"]}

--- a/appveyor_ok_list.json
+++ b/appveyor_ok_list.json
@@ -1,1 +1,1 @@
-{"ok": ["gdcm", "isl", "simbody", "sdl2_mixer", "czmq", "helics", "gsl-lite"]}
+{"ok": ["isl", "simbody", "sdl2_mixer", "czmq", "helics", "gsl-lite"]}

--- a/appveyor_ok_list.json
+++ b/appveyor_ok_list.json
@@ -1,0 +1,1 @@
+{"ok": ["armadillo", "gdcm", "isl", "libssh2", "simbody", "sdl2_mixer", "sdl2_image", "czmq", "helics", "gsl-lite"]}

--- a/appveyor_ok_list.json
+++ b/appveyor_ok_list.json
@@ -1,1 +1,1 @@
-{"ok": ["isl", "simbody", "sdl2_mixer", "helics", "gsl-lite"]}
+{"ok": ["isl", "simbody", "sdl2_mixer", "gsl-lite"]}


### PR DESCRIPTION
I've gone through the rest of the feedstocks that have appveyor.

The ones on this list currently use appveyor to build on master and have been worked on recently. 

Everything else has been 
 - moved to azure
 - uses appveyor on a version branch (e.g. python)
 - uses appveyor on a PR branch that should not be there
 - is a recipe that is 1.5 years to 4 years out of date

I have left these feedstocks off the list under the assumptions that 

1. should they ever get updated (either in a branch on master, we would rerender and move to azure)
2. we can add any feedstock back later

Hopefully `isl` and `libssh2` can be moved over to azure before this PR is merged.

cc @conda-forge/core for viz

here are my notes: https://hackmd.io/HSwAaR3ZTzSA70kSiPRwcg?edit