### PR TITLE
Allow gnuradio-soapy from gnuradio

### DIFF
--- a/outputs/g/n/u/gnuradio-soapy.json
+++ b/outputs/g/n/u/gnuradio-soapy.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["gnuradio-soapy"]}
+{"feedstocks": ["gnuradio", "gnuradio-soapy"]}


### PR DESCRIPTION
The gnuradio soapy module has been merged into the main gnuradio code, and so now it can be an output of the gnuradio feedstock instead of the separate gnuradio-soapy feedstock.