### PR TITLE
fenics-ufl: allow uploads from new fenics-ufl feedstock repo

### DIFF
--- a/outputs/f/e/n/fenics-ufl.json
+++ b/outputs/f/e/n/fenics-ufl.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["fenics"]}
+{"feedstocks": ["fenics", "fenics-ufl"]}


### PR DESCRIPTION
part of fenicsx packaging, with separate repos for packages instead of single feedstock.
