### PR TITLE
fix recently added fenicsx feedstock feedstock names

### DIFF
--- a/outputs/f/e/n/fenics-basix.json
+++ b/outputs/f/e/n/fenics-basix.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["fenics-basix-meta"]}
+{"feedstocks": ["fenics-basix-meta", "fenics-basix"]}

--- a/outputs/f/e/n/fenics-ffcx.json
+++ b/outputs/f/e/n/fenics-ffcx.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["fenics-ffcx-ufcx"]}
+{"feedstocks": ["fenics-ffcx-ufcx", "fenics-ffcx"]}

--- a/outputs/f/e/n/fenics-libbasix.json
+++ b/outputs/f/e/n/fenics-libbasix.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["fenics-basix-meta"]}
+{"feedstocks": ["fenics-basix-meta", "fenics-basix"]}

--- a/outputs/f/e/n/fenics-ufcx.json
+++ b/outputs/f/e/n/fenics-ufcx.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["fenics-ffcx-ufcx"]}
+{"feedstocks": ["fenics-ffcx-ufcx", "fenics-ffcx"]}


### PR DESCRIPTION
rather than their logical names, the recipes used mangled names to avoid https://github.com/conda/conda-build/issues/3313

Setting `extra.feedstock-name` prior to merge would have avoided this, but I didn't know about that field yet.

I'll rename the feedstock repos when this is merged:

- https://github.com/conda-forge/fenics-ffcx-ufcx-feedstock/pull/2
- https://github.com/conda-forge/fenics-basix-meta-feedstock/pull/7
