### PR TITLE
move dvc subpackages into separate feedstocks

### DIFF
--- a/outputs/d/v/c/dvc-azure.json
+++ b/outputs/d/v/c/dvc-azure.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dvc"]}
+{"feedstocks": ["dvc", "dvc-azure"]}

--- a/outputs/d/v/c/dvc-gdrive.json
+++ b/outputs/d/v/c/dvc-gdrive.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dvc"]}
+{"feedstocks": ["dvc", "dvc-gdrive"]}

--- a/outputs/d/v/c/dvc-gs.json
+++ b/outputs/d/v/c/dvc-gs.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dvc"]}
+{"feedstocks": ["dvc", "dvc-gs"]}

--- a/outputs/d/v/c/dvc-hdfs.json
+++ b/outputs/d/v/c/dvc-hdfs.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dvc"]}
+{"feedstocks": ["dvc", "dvc-hdfs"]}

--- a/outputs/d/v/c/dvc-oss.json
+++ b/outputs/d/v/c/dvc-oss.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dvc"]}
+{"feedstocks": ["dvc", "dvc-oss"]}

--- a/outputs/d/v/c/dvc-s3.json
+++ b/outputs/d/v/c/dvc-s3.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dvc"]}
+{"feedstocks": ["dvc", "dvc-s3"]}

--- a/outputs/d/v/c/dvc-ssh.json
+++ b/outputs/d/v/c/dvc-ssh.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dvc"]}
+{"feedstocks": ["dvc", "dvc-ssh"]}

--- a/outputs/d/v/c/dvc-webdav.json
+++ b/outputs/d/v/c/dvc-webdav.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dvc"]}
+{"feedstocks": ["dvc", "dvc-webdav"]}

--- a/outputs/d/v/c/dvc-webhdfs.json
+++ b/outputs/d/v/c/dvc-webhdfs.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dvc"]}
+{"feedstocks": ["dvc", "dvc-webhdfs"]}


### PR DESCRIPTION
We've created packages for dvc plugins in conda-forge/staged-recipes#20108
but dvc-feedstock already generated some subpackages with similar names,
so we need to adjust that here. dvc-feedstock will be adjusted to stop
generating those subpackages in the next release.

Similar to #36
Related to conda-forge/dvc-feedstock#273

Fixes conda-forge/dvc-azure-feedstock#1
Fixes conda-forge/dvc-gdrive-feedstock#1
Fixes conda-forge/dvc-s3-feedstock#1
Fixes conda-forge/dvc-gs-feedstock#1
Fixes conda-forge/dvc-hdfs-feedstock#1
Fixes conda-forge/dvc-oss-feedstock#1
Fixes conda-forge/dvc-ssh-feedstock#1
Fixes conda-forge/dvc-webdav-feedstock#1
Fixes conda-forge/dvc-webhdfs-feedstock#1

