### PR TITLE
allow cryptography-vectors to be built on cryptography feedstock

### DIFF
--- a/outputs/c/r/y/cryptography-vectors.json
+++ b/outputs/c/r/y/cryptography-vectors.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["cryptography-vectors"]}
+{"feedstocks": ["cryptography", "cryptography-vectors"]}


### PR DESCRIPTION
To allow unifying feedstocks (otherwise every upgrade PR fails right off the bat), see https://github.com/conda-forge/cryptography-feedstock/pull/111