### PR TITLE
allow gym-* to be built as compat outputs of successor gymnasium

### DIFF
--- a/outputs/g/y/m/gym-all.json
+++ b/outputs/g/y/m/gym-all.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["gym"]}
+{"feedstocks": ["gym", "gymnasium"]}

--- a/outputs/g/y/m/gym-atari.json
+++ b/outputs/g/y/m/gym-atari.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["gym"]}
+{"feedstocks": ["gym", "gymnasium"]}

--- a/outputs/g/y/m/gym-box2d.json
+++ b/outputs/g/y/m/gym-box2d.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["gym"]}
+{"feedstocks": ["gym", "gymnasium"]}

--- a/outputs/g/y/m/gym-classic_control.json
+++ b/outputs/g/y/m/gym-classic_control.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["gym"]}
+{"feedstocks": ["gym", "gymnasium"]}

--- a/outputs/g/y/m/gym-mujoco.json
+++ b/outputs/g/y/m/gym-mujoco.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["gym"]}
+{"feedstocks": ["gym", "gymnasium"]}

--- a/outputs/g/y/m/gym-other.json
+++ b/outputs/g/y/m/gym-other.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["gym"]}
+{"feedstocks": ["gym", "gymnasium"]}

--- a/outputs/g/y/m/gym-toy_text.json
+++ b/outputs/g/y/m/gym-toy_text.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["gym"]}
+{"feedstocks": ["gym", "gymnasium"]}

--- a/outputs/g/y/m/gym.json
+++ b/outputs/g/y/m/gym.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["gym"]}
+{"feedstocks": ["gym", "gymnasium"]}


### PR DESCRIPTION
Gym turned into gymnasium, but the naming change got tangled up with long-pending new dependencies and a new feedstock being created in the meantime. To maintain the history of the old feedstock (in the new one), we'll rebuild gym one last [time](https://github.com/conda-forge/gymnasium-feedstock/pull/9) on the gymnasium feedstock, and then switch -- it's possible/likely we might want to keep them as compatibility outputs, so this is not a one-time change. For more discussion see https://github.com/conda-forge/staged-recipes/pull/21485.