### PR TITLE
enable unification of cpp-opentelemetry feedstocks

### DIFF
--- a/outputs/c/p/p/cpp-opentelemetry-api.json
+++ b/outputs/c/p/p/cpp-opentelemetry-api.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["cpp-opentelemetry-api"]}
+{"feedstocks": ["cpp-opentelemetry-api", "cpp-opentelemetry-sdk"]}


### PR DESCRIPTION
Once this & https://github.com/conda-forge/cpp-opentelemetry-sdk-feedstock/pull/46 are merged, we can archive https://github.com/conda-forge/cpp-opentelemetry-api-feedstock