### PR TITLE
Update trio_asyncio.json

### DIFF
--- a/outputs/t/r/i/trio_asyncio.json
+++ b/outputs/t/r/i/trio_asyncio.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["trio_asyncio"]}
+{"feedstocks": ["trio-asyncio"]}


### PR DESCRIPTION
The `trio_asyncio` feedstock is being consolidated into the `trio-asyncio` feedstock:
https://github.com/conda-forge/trio-asyncio-feedstock/pull/13