### PR TITLE
Allow awscli uploads from awscli2

### DIFF
--- a/outputs/a/w/s/awscli.json
+++ b/outputs/a/w/s/awscli.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["awscli"]}
+{"feedstocks": ["awscli", "awscli2"]}


### PR DESCRIPTION
Required so that we can upload `awscli=2.*` from https://github.com/conda-forge/awscli2-feedstock