### PR TITLE
allow m2w64-gcc-libs-feedstock for gcc runtime libraries

### DIFF
--- a/outputs/l/i/b/libgfortran.json
+++ b/outputs/l/i/b/libgfortran.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["libgfortran", "gfortran_impl_osx-64"]}
+{"feedstocks": ["libgfortran", "gfortran_impl_osx-64", "m2w64-gcc-libs"]}

--- a/outputs/l/i/b/libgfortran5.json
+++ b/outputs/l/i/b/libgfortran5.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["gfortran_impl_osx-64", "ctng-compilers"]}
+{"feedstocks": ["gfortran_impl_osx-64", "ctng-compilers", "m2w64-gcc-libs"]}

--- a/outputs/l/i/b/libgomp.json
+++ b/outputs/l/i/b/libgomp.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["ctng-compilers"]}
+{"feedstocks": ["ctng-compilers", "m2w64-gcc-libs"]}


### PR DESCRIPTION
Fixes https://github.com/conda-forge/m2w64-gcc-libs-feedstock/issues/1