### PR TITLE
allow non-core dagster libs from dagster-libs

### DIFF
--- a/outputs/d/a/g/dagster-airbyte.json
+++ b/outputs/d/a/g/dagster-airbyte.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-aws.json
+++ b/outputs/d/a/g/dagster-aws.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-bash.json
+++ b/outputs/d/a/g/dagster-bash.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-celery-docker.json
+++ b/outputs/d/a/g/dagster-celery-docker.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-celery-k8s.json
+++ b/outputs/d/a/g/dagster-celery-k8s.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-celery.json
+++ b/outputs/d/a/g/dagster-celery.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-census.json
+++ b/outputs/d/a/g/dagster-census.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-cron.json
+++ b/outputs/d/a/g/dagster-cron.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-dask.json
+++ b/outputs/d/a/g/dagster-dask.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-datadog.json
+++ b/outputs/d/a/g/dagster-datadog.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-dbt.json
+++ b/outputs/d/a/g/dagster-dbt.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-docker.json
+++ b/outputs/d/a/g/dagster-docker.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-duckdb-pandas.json
+++ b/outputs/d/a/g/dagster-duckdb-pandas.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-duckdb-polars.json
+++ b/outputs/d/a/g/dagster-duckdb-polars.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-duckdb-pyspark.json
+++ b/outputs/d/a/g/dagster-duckdb-pyspark.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-duckdb.json
+++ b/outputs/d/a/g/dagster-duckdb.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-ext-process.json
+++ b/outputs/d/a/g/dagster-ext-process.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-fivetran.json
+++ b/outputs/d/a/g/dagster-fivetran.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-gcp-pandas.json
+++ b/outputs/d/a/g/dagster-gcp-pandas.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-gcp-pyspark.json
+++ b/outputs/d/a/g/dagster-gcp-pyspark.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-gcp.json
+++ b/outputs/d/a/g/dagster-gcp.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-ge.json
+++ b/outputs/d/a/g/dagster-ge.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-github.json
+++ b/outputs/d/a/g/dagster-github.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-k8s.json
+++ b/outputs/d/a/g/dagster-k8s.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-managed-elements.json
+++ b/outputs/d/a/g/dagster-managed-elements.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-mlflow.json
+++ b/outputs/d/a/g/dagster-mlflow.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-msteams.json
+++ b/outputs/d/a/g/dagster-msteams.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-mysql.json
+++ b/outputs/d/a/g/dagster-mysql.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-pagerduty.json
+++ b/outputs/d/a/g/dagster-pagerduty.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-pandas.json
+++ b/outputs/d/a/g/dagster-pandas.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-pandera.json
+++ b/outputs/d/a/g/dagster-pandera.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-papertrail.json
+++ b/outputs/d/a/g/dagster-papertrail.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-postgres.json
+++ b/outputs/d/a/g/dagster-postgres.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-prometheus.json
+++ b/outputs/d/a/g/dagster-prometheus.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-pyspark.json
+++ b/outputs/d/a/g/dagster-pyspark.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-shell.json
+++ b/outputs/d/a/g/dagster-shell.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-slack.json
+++ b/outputs/d/a/g/dagster-slack.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-snowflake-pandas.json
+++ b/outputs/d/a/g/dagster-snowflake-pandas.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-snowflake-pyspark.json
+++ b/outputs/d/a/g/dagster-snowflake-pyspark.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-snowflake.json
+++ b/outputs/d/a/g/dagster-snowflake.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-spark.json
+++ b/outputs/d/a/g/dagster-spark.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-ssh.json
+++ b/outputs/d/a/g/dagster-ssh.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-twilio.json
+++ b/outputs/d/a/g/dagster-twilio.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagster-wandb.json
+++ b/outputs/d/a/g/dagster-wandb.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}

--- a/outputs/d/a/g/dagstermill.json
+++ b/outputs/d/a/g/dagstermill.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dagster"]}
+{"feedstocks": ["dagster-libs"]}


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

References:
- on `dagster-feedstock`: 
  - original issue: https://github.com/conda-forge/dagster-feedstock/issues/301
  - pr to remove outputs: https://github.com/conda-forge/dagster-feedstock/pull/304
- on `staged-recipes`: 
  - https://github.com/conda-forge/staged-recipes/pull/24424/
- on `dagster-libs-feedstock`
  - retry-spinning build that will probably timeout: https://github.com/conda-forge/dagster-libs-feedstock/runs/18398743992
