### PR TITLE
allow `libgoogle-cloud` to be built by new google-cloud-cpp-core feedstock

### DIFF
--- a/outputs/l/i/b/libgoogle-cloud.json
+++ b/outputs/l/i/b/libgoogle-cloud.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["google-cloud-cpp"]}
+{"feedstocks": ["google-cloud-cpp", "google-cloud-cpp-core"]}


### PR DESCRIPTION
Necessary for https://github.com/conda-forge/staged-recipes/pull/24818