### PR TITLE
use jupyter_sphinx as an alias for jupyter-sphinx

### DIFF
--- a/outputs/j/u/p/jupyter_sphinx.json
+++ b/outputs/j/u/p/jupyter_sphinx.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["jupyter_sphinx"]}
+{"feedstocks": ["jupyter-sphinx"]}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

related to https://github.com/conda-forge/jupyter_sphinx-feedstock/issues/27

I am a new maintainer of the jupyter-sphinx package and by setting up the badges in the readme file I realized there are 2 feedstocks wired to the same package.

It was mentioned a long time ago in https://github.com/jupyter/jupyter-sphinx/issues/148 but it seems nobody took actions.

we have:

https://github.com/conda-forge/jupyter_sphinx-feedstock
https://github.com/conda-forge/jupyter-sphinx-feedstock

I would like to only keep the "jupyter-sphinx" one to use the same naming convention as in the pypi package. To my undestanding the first step is to use jupyter_sphinx as an alias for the main feedstock which I think this PR is doing. 
Any other guidances will be welcomed. 
