### PR TITLE
ENH add flit-core output

### DIFF
--- a/outputs/f/l/i/flit-core.json
+++ b/outputs/f/l/i/flit-core.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["flit"]}
+{"feedstocks": ["flit", "flit-core"]}


### PR DESCRIPTION
This PR is adding the flit-core output for the new flit-core feedstock per https://github.com/conda-forge/flit-feedstock/issues/38. 

Merge with https://github.com/conda-forge/staged-recipes/pull/25847