### PR TITLE
allow gcc, gxx and gfortran from ctng-compilers-feedstock

### DIFF
--- a/outputs/g/c/c/gcc.json
+++ b/outputs/g/c/c/gcc.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["ctng-compiler-activation"]}
+{"feedstocks": ["ctng-compiler-activation", "ctng-compilers"]}

--- a/outputs/g/f/o/gfortran.json
+++ b/outputs/g/f/o/gfortran.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["gfortran_osx-64", "ctng-compiler-activation"]}
+{"feedstocks": ["gfortran_osx-64", "ctng-compiler-activation", "ctng-compilers"]}

--- a/outputs/g/x/x/gxx.json
+++ b/outputs/g/x/x/gxx.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["ctng-compiler-activation"]}
+{"feedstocks": ["ctng-compiler-activation", "ctng-compilers"]}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
