### PR TITLE
Prepare for splitting out dbt-postgres into new feedstock

### DIFF
--- a/outputs/d/b/t/dbt-postgres.json
+++ b/outputs/d/b/t/dbt-postgres.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["dbt"]}
+{"feedstocks": ["dbt", "dbt-postgres"]}


### PR DESCRIPTION
As of v1.8.0, the dbt-postgres adapter has been [split from dbt-core](https://github.com/dbt-labs/dbt-core/blob/8fe7d652ab60990c564d4acc7aa80ae96d8be6f0/ARCHITECTURE.md):

![image](https://github.com/conda-forge/feedstock-outputs/assets/15216687/ae9a84fa-932b-40fd-916c-bfdd5547048f)

Thus I'm about to create a new staged recipe, and want the output to be writable. 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
