### PR TITLE
Move omniorbpy to omniorb feedstock

### DIFF
--- a/outputs/o/m/n/omniorbpy.json
+++ b/outputs/o/m/n/omniorbpy.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["omniorbpy"]}
+{"feedstocks": ["omniorbpy", "omniorb"]}


### PR DESCRIPTION
<!-- 
Thank you for making a PR to `conda-forge/feedstock-outputs`!

Please check the items below. 
-->

PR Checklist: 
  - [X] No trailing commas in JSON blobs.
  - [X] New feedstocks are appended to the list.
  - [X] Old feedstock entries are NOT removed.
  - [X] Listed additional details below about why this change is being made.

Additional Details:
<!-- Please list any additional details here. -->

In PR https://github.com/conda-forge/omniorb-feedstock/pull/53, omniorbpy package was moved to the ominorb-feedstock

I asked to archive the omniorbpy-feedstock and was [told](https://github.com/conda-forge/admin-requests/pull/1026#issuecomment-2225346374) to open a PR here to allow pushing omniorbpy from ominorb-feedstock