### PR TITLE
allow grpcio-tools to be built on main grpc feedstock

### DIFF
--- a/outputs/g/r/p/grpcio-tools.json
+++ b/outputs/g/r/p/grpcio-tools.json
@@ -1,1 +1,1 @@
-{"feedstocks": ["grpcio-tools"]}
+{"feedstocks": ["grpc-cpp", "grpcio-tools"]}


### PR DESCRIPTION
For reasoning see [here](https://github.com/conda-forge/grpc-cpp-feedstock/pull/370#issuecomment-2366964748)