### PR TITLE
Register pyramids-stac output for pyramids-feedstock

### DIFF
--- a/outputs/p/y/r/pyramids-stac.json
+++ b/outputs/p/y/r/pyramids-stac.json
@@ -1,0 +1,1 @@
+{"feedstocks": ["pyramids"]}


### PR DESCRIPTION
Registers the new `pyramids-stac` output produced by `pyramids-feedstock`.

The `pyramids` 0.21.0 recipe adds a `pyramids-stac` subpackage output. Output validation in
the feedstock build currently rejects it because the output is not yet registered:

```
"noarch/pyramids-stac-0.21.0-hd8ed1ab_0.conda": false
```

This adds `outputs/p/y/r/pyramids-stac.json` mapping the output to the `pyramids` feedstock,
consistent with the other registered `pyramids-*` outputs.