### PR TITLE
Register soundfile output for pysoundfile feedstock

### DIFF
--- a/outputs/s/o/u/soundfile.json
+++ b/outputs/s/o/u/soundfile.json
@@ -1,0 +1,1 @@
+{"feedstocks": ["pysoundfile"]}


### PR DESCRIPTION
Registers the new `soundfile` output name to the existing `pysoundfile` feedstock.

The upstream project was renamed `pysoundfile` → `soundfile`. The feedstock (conda-forge/pysoundfile-feedstock) is migrating to build under the canonical `soundfile` name while keeping a `pysoundfile` transition metapackage. See conda-forge/pysoundfile-feedstock#30 (and #23).

The `soundfile` output name is currently unregistered/unused.