### PR TITLE
Add onnxruntime-ep-cuda output for the onnxruntime feedstock

### DIFF
--- a/outputs/o/n/n/onnxruntime-ep-cuda.json
+++ b/outputs/o/n/n/onnxruntime-ep-cuda.json
@@ -1,0 +1,1 @@
+{"feedstocks": ["onnxruntime"]}


### PR DESCRIPTION
onnxruntime 1.28.0 can build its CUDA execution provider as a standalone, Python-independent plugin library (`onnxruntime_BUILD_CUDA_EP_AS_PLUGIN=ON`, loaded via the EP plugin API into any onnxruntime core >= 1.24.4).

conda-forge/onnxruntime-feedstock#198 restructures the feedstock accordingly: the `onnxruntime`/`onnxruntime-cpp` packages become CPU-only and a new `onnxruntime-ep-cuda` output (one build per platform x CUDA version, no Python dimension) provides GPU support. Its CI currently fails only output validation for the new name.

Discussion/design: conda-forge/onnxruntime-feedstock#196, #197, #198 (cc @cbourjau).